### PR TITLE
creation and population of geom columns on datastore upload

### DIFF
--- a/ckanext/xloader/jobs.py
+++ b/ckanext/xloader/jobs.py
@@ -258,6 +258,31 @@ def xloader_data_into_datastore_(input, job_dict):
 
     tmp_file.close()
 
+    flag_count = 0
+    try:
+        datastore_dict = get_action('datastore_search')({},{'id': resource['id'], 'limit': 0})
+        fields = datastore_dict.get('fields')
+        for field in fields:
+            if field.get('id') == 'latitude' or field.get('id') == 'longitude':
+                if field.get('type') == 'numeric':
+                    flag_count = flag_count + 1
+            if flag_count == 2:
+                get_action('create_geom_columns')(
+                    None,
+                    {
+                        'resource_id': resource['id'],
+                        'populate': True,
+                        'index': True,
+                        # The dataset fields containing the latitude and longitude columns.
+                        'latitude_field': 'latitude',
+                        'longitude_field': 'longitude'
+                    }
+                )
+                logger.info('Geom columns created and populated')
+                break
+    except:
+        logger.info('Datastore not found for the resource')
+
     logger.info('Express Load completed')
 
 

--- a/ckanext/xloader/jobs.py
+++ b/ckanext/xloader/jobs.py
@@ -259,29 +259,35 @@ def xloader_data_into_datastore_(input, job_dict):
     tmp_file.close()
 
     flag_count = 0
+    fields = []
     try:
         datastore_dict = get_action('datastore_search')({},{'id': resource['id'], 'limit': 0})
         fields = datastore_dict.get('fields')
-        for field in fields:
-            if field.get('id') == 'latitude' or field.get('id') == 'longitude':
-                if field.get('type') == 'numeric':
-                    flag_count = flag_count + 1
-            if flag_count == 2:
-                get_action('create_geom_columns')(
-                    None,
-                    {
-                        'resource_id': resource['id'],
-                        'populate': True,
-                        'index': True,
-                        # The dataset fields containing the latitude and longitude columns.
-                        'latitude_field': 'latitude',
-                        'longitude_field': 'longitude'
-                    }
-                )
-                logger.info('Geom columns created and populated')
-                break
     except:
         logger.info('Datastore not found for the resource')
+
+    for field in fields:
+        if field.get('id') == 'latitude' or field.get('id') == 'longitude':
+            if field.get('type') == 'numeric':
+                flag_count = flag_count + 1
+            if flag_count == 2:
+                try:
+                    get_action('create_geom_columns')(
+                        None,
+                        {
+                            'resource_id': resource['id'],
+                            'populate': True,
+                            'index': True,
+                            # The dataset fields containing the latitude and longitude columns.
+                            'latitude_field': 'latitude',
+                            'longitude_field': 'longitude'
+                        }
+                    )
+                    logger.info('Geom columns created and populated')
+                    break
+                except:
+                    logger.error('Error in create_geom_columns action')
+                    break
 
     logger.info('Express Load completed')
 

--- a/ckanext/xloader/jobs.py
+++ b/ckanext/xloader/jobs.py
@@ -286,7 +286,7 @@ def xloader_data_into_datastore_(input, job_dict):
                     logger.info('Geom columns created and populated')
                     break
                 except:
-                    logger.error('Error in create_geom_columns action')
+                    logger.error('error in action call to create_geom_columns')
                     break
 
     logger.info('Express Load completed')


### PR DESCRIPTION
creation and population of geom columns on resource datastore upload
Steps to test this PR:
1)Install ckanext-dataspatial and ckanext-xloader
2)add a dataset resource with spatial fields latitude and longitude columns
3)Update the data dictionary for columns latitude and longitude to field type as numeric
4)Re-upload the resource to datastore
5)Query the datastore of the resource using dataspatial search query
eg:
/api/3/action/datastore_search_sql?sql= SELECT * FROM "resource_id" WHERE ST_Intersects("_geom", ST_GeomFromText('POLYGON((-80.030282 40.454659, -79.979814 40.454659, -79.979814 40.409188, -80.030282 40.409188, -80.030282 40.454659))', 4326))