### PR TITLE
[OD-767] Add datastore_search_sql cache purge script to xloader

### DIFF
--- a/ckanext/xloader/jobs.py
+++ b/ckanext/xloader/jobs.py
@@ -9,6 +9,9 @@ import datetime
 import traceback
 import sys
 
+import subprocess
+from os import path
+
 import requests
 from rq import get_current_job
 import sqlalchemy as sa
@@ -35,6 +38,7 @@ MAX_CONTENT_LENGTH = config.get('ckanext.xloader.max_content_length') or 1e9
 CHUNK_SIZE = 16 * 1024  # 16kb
 DOWNLOAD_TIMEOUT = 30
 
+DATASTORE_CACHE_DIR = config.get('datastore_cache_dir')
 
 # 'api_key': user['apikey'],
 # 'job_type': 'push_to_datastore',
@@ -276,6 +280,16 @@ def xloader_data_into_datastore_(input, job_dict):
         logger.info('Finished loading with messytables')
 
     tmp_file.close()
+
+    # Purge nginx cache
+    if DATASTORE_CACHE_DIR:
+        base_path = path.abspath(path.dirname(__file__))
+        purge_script = path.join(base_path, 'nginx-cache-purge.sh')
+
+        purge_params = [purge_script, resource_id, DATASTORE_CACHE_DIR]
+        purge_process = subprocess.Popen(purge_params, stdout=subprocess.PIPE, stderr=subprocess.STDOUT)
+        purge_result = purge_process.stdout.read()
+        logger.info('Purge cache: {purge_result}'.format(purge_result=purge_result))
 
     logger.info('Express Load completed')
 

--- a/ckanext/xloader/jobs.py
+++ b/ckanext/xloader/jobs.py
@@ -38,7 +38,8 @@ MAX_CONTENT_LENGTH = config.get('ckanext.xloader.max_content_length') or 1e9
 CHUNK_SIZE = 16 * 1024  # 16kb
 DOWNLOAD_TIMEOUT = 30
 
-DATASTORE_CACHE_DIR = config.get('datastore_cache_dir')
+DATASTORE_CACHE_DIR = config.get('datastore_cache_dir') or \
+                      '/tmp/datastore_cache/'
 
 # 'api_key': user['apikey'],
 # 'job_type': 'push_to_datastore',
@@ -281,15 +282,19 @@ def xloader_data_into_datastore_(input, job_dict):
 
     tmp_file.close()
 
-    # Purge nginx cache
-    if DATASTORE_CACHE_DIR:
+    # Purge nginx cache based on resource id
+    if path.isdir(DATASTORE_CACHE_DIR):
+        # Path of purge script
         base_path = path.abspath(path.dirname(__file__))
         purge_script = path.join(base_path, 'nginx-cache-purge.sh')
 
+        # Run script as subprocess
         purge_params = [purge_script, resource_id, DATASTORE_CACHE_DIR]
-        purge_process = subprocess.Popen(purge_params, stdout=subprocess.PIPE, stderr=subprocess.STDOUT)
+        purge_process = subprocess.Popen(purge_params,
+                                         stdout=subprocess.PIPE,
+                                         stderr=subprocess.STDOUT)
         purge_result = purge_process.stdout.read()
-        logger.info('Purge cache: {purge_result}'.format(purge_result=purge_result))
+        logger.info('Purge cache: {result}'.format(result=purge_result))
 
     logger.info('Express Load completed')
 

--- a/ckanext/xloader/nginx-cache-purge.sh
+++ b/ckanext/xloader/nginx-cache-purge.sh
@@ -1,0 +1,82 @@
+#!/bin/bash
+
+# nginx-cache-purge --- A simple Bash script to delete an item or set
+#                       of items specified through a grep pattern from
+#                       the Nginx cache.
+
+# Copyright (C) 2011 António P. P. Almeida <appa@perusio.net>
+
+# Author: António P. P. Almeida <appa@perusio.net>
+
+# Permission is hereby granted, free of charge, to any person obtaining a
+# copy of this software and associated documentation files (the "Software"),
+# to deal in the Software without restriction, including without limitation
+# the rights to use, copy, modify, merge, publish, distribute, sublicense,
+# and/or sell copies of the Software, and to permit persons to whom the
+# Software is furnished to do so, subject to the following conditions:
+
+# The above copyright notice and this permission notice shall be included in
+# all copies or substantial portions of the Software.
+
+# Except as contained in this notice, the name(s) of the above copyright
+# holders shall not be used in advertising or otherwise to promote the sale,
+# use or other dealings in this Software without prior written authorization.
+
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.  IN NO EVENT SHALL
+# THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+# FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+# DEALINGS IN THE SOFTWARE.
+
+SCRIPTNAME=${0##*/}
+
+function print_usage() {
+    echo "$SCRIPTNAME <URI (grep pattern)> <cache directory>."
+}
+
+## Check the number of arguments.
+if [ $# -ne 2 ]; then
+    print_usage
+    exit 1
+fi
+
+## Return the files where the items are cached.
+## $1 - the filename, can be a pattern .
+## $2 - the cache directory.
+## $3 - (optional) the number of parallel processes to run for grep.
+function get_cache_files() {
+    ## The maximum number of parallel processes. 16 since the cache
+    ## naming scheme is hex based.
+    local max_parallel=${3-16}
+    ## Get the cache files running grep in parallel for each top level
+    ## cache dir.
+    find $2 -maxdepth 1 -type d | xargs -P $max_parallel -n 1 grep -ERl "^KEY:.*$1" | sort -u
+} # get_cache_files
+
+## Removes an item from the given cache zone.
+## $1 - the filename, can be a pattern .
+## $2 - the cache directory.
+function nginx_cache_purge_item() {
+    local cache_files
+
+    [ -d $2 ] || exit 2
+    cache_files=$(get_cache_files "$1" $2)
+
+    ## Act based on grep result.
+    if [ -n "$cache_files" ]; then
+        ## Loop over all matched items.
+        for i in $cache_files; do
+            [ -f $i ] || continue
+            echo "Deleting $i from $2."
+            rm $i
+        done
+    else
+        echo "$1 is not cached."
+        exit 3
+    fi
+} # nginx_cache_purge_item
+
+## Try to purge the given item from the cache.
+nginx_cache_purge_item $1 $2


### PR DESCRIPTION
[[OD-767] Add datastore_search_sql cache purge script to xloader](https://opengovinc.atlassian.net/browse/OD-767)

## Description
API calls to the datastore_search_sql and odata endpoints are cached in nginx. According to our nginx configuration we keep the cache in /tmp/datastore_cache/ for 24 hours.

We need to clear the cache when users upload a new file. This ensures that users will get the latest data when the they make a new API call to datastore_search_sql or odata.

## Changes
This PR adds a script from https://github.com/perusio/nginx-cache-purge to purge the cache based on a given resource id. The script will remove any file in the cache directory that has the given resource id in it.

## Test Procedure
* Install xloader with the changes from this PR
* Create a cache directory at `/tmp/datastore_cache/` or set a new cache directory in the ini config file using `datastore_cache_dir  = /new_datastore_cache`. Make sure the user CKAN is running as has permission to the directory
* Restart the supervisor service
* Go to the datastore tab in a resource's edit page and push the resource data to the datastore again. In the log of the datastore tab there should be a mention of `Purge cache` and the result.

## Approval Criteria
Files with a resource id in the content should be deleted from `/tmp/datastore_cache/` after clicking `Upload to Datastore` on the datastore tab of the resource edit page.

## Submitter Checklist
- [x] I have tested the changes locally