### PR TITLE
[ESN-3649] Retry on 404 error in case file isn't ready in cloud storage

### DIFF
--- a/ckanext/xloader/jobs.py
+++ b/ckanext/xloader/jobs.py
@@ -342,12 +342,13 @@ def get_response(url, headers):
             stream=True,  # just gets the headers for now
         )
     response = get_url()
-    if response.status_code == 202:
+    if response.status_code in [202, 404]:
         # Seen: https://data-cdfw.opendata.arcgis.com/datasets
         # In this case it means it's still processing, so do retries.
         # 202 can mean other things, but there's no harm in retries.
+        # Retry for 404 in case file isn't ready in cloud storage.
         wait = 1
-        while wait < 120 and response.status_code == 202:
+        while wait < 120 and response.status_code in [202, 404]:
             # logger.info('Retrying after {}s'.format(wait))
             time.sleep(wait)
             response = get_url()


### PR DESCRIPTION
<!--- Title Link to Jira Ticket - UPDATE WITH YOUR TICKET TAG in name and url --->
## [TICKET](https://opengovinc.atlassian.net/browse/ESN-3649)

## Description
Occasionally xloader will get a 404 error when trying to fetch a file from cloud storage. This occurs when the file on s3 isn't available immediately. Xloader should try to fetch the file again a few times. After a couple of minutes xloader will stop trying and display the final error message.

## Testing
- Install xloader
- Upload a file and check that xloader pushes the data to the datastore
- Link a file that doesn't exist and check that xloader tries to fetch the file for up to 2 minutes

## Screenshots
After a couple of minutes of trying to fetch file Xloader will stop and display error for 404.
<img width="1356" alt="Screen Shot 2021-05-05 at 12 46 40 PM" src="https://user-images.githubusercontent.com/4096633/117178394-f95da000-ad9f-11eb-85db-6a2da8526364.png">