### PR TITLE
[ESN-3904] Catch UnicodeDecodeError when guessing delimiter.

### DIFF
--- a/ckanext/xloader/loader.py
+++ b/ckanext/xloader/loader.py
@@ -81,6 +81,9 @@ def load_csv(csv_filepath, resource_id, mimetype='text/csv', logger=None):
     except csv.Error:
         logger.warning('Could not determine delimiter from file, use default ","')
         delimiter = ','
+    except UnicodeDecodeError as e:
+        raise LoaderError('Could not determine delimiter from file: {}'
+                          .format(e))
 
     # Setup the converters that run when you iterate over the row_set.
     # With pgloader only the headers will be iterated over.


### PR DESCRIPTION
## Description
This PR fixes a bug when xloader tries to guess a file's delimiter when using COPY. For Excel files this will throw an UnicodeDecodeError exception. To fix this we catch the exception and try again with messytables to upload the Excel file.

## Screenshot
![Screen Shot 2021-06-17 at 2 12 32 PM](https://user-images.githubusercontent.com/4096633/122451411-17f5b000-cf76-11eb-8889-4bdfe0958d6c.png)
