### PR TITLE
Fix issue with callback url for xloader_hook

### DIFF
--- a/ckanext/xloader/action.py
+++ b/ckanext/xloader/action.py
@@ -137,19 +137,17 @@ def xloader_submit(context, data_dict):
         task
     )
 
-    callback_url = p.toolkit.url_for(
-        "api.action",
-        ver=3,
-        logic_function="xloader_hook",
-        qualified=True
-    )
+    # Don't use url_for() due to compatibility issue with older CKAN versions
+    site_url = config['ckan.site_url']
+    callback_url = site_url + '/api/3/action/xloader_hook'
+
     data = {
         'api_key': utils.get_xloader_user_apitoken(),
         'job_type': 'xloader_to_datastore',
         'result_url': callback_url,
         'metadata': {
             'ignore_hash': data_dict.get('ignore_hash', False),
-            'ckan_url': config['ckan.site_url'],
+            'ckan_url': site_url,
             'resource_id': res_id,
             'set_url_type': data_dict.get('set_url_type', False),
             'task_created': task['last_updated'],


### PR DESCRIPTION
## Description
This PR fixes an issue when url_for() is used to get the url for xloader_hook.
The issue is due to a compatibility issue with older CKAN versions where `api.action` is not recognized.

On CKAN 2.7 the status of xloader jobs are never changed from `pending` since calls to xloader_hook to update job status fail.