### PR TITLE
Restart _id sequence after table truncate

### DIFF
--- a/ckanext/xloader/loader.py
+++ b/ckanext/xloader/loader.py
@@ -119,7 +119,7 @@ def _clear_datastore_resource(resource_id):
     engine = get_write_engine()
     with engine.begin() as conn:
         conn.execute("SET LOCAL lock_timeout = '5s'")
-        conn.execute('TRUNCATE TABLE "{}"'.format(resource_id))
+        conn.execute('TRUNCATE TABLE "{}" RESTART IDENTITY'.format(resource_id))
 
 
 def load_csv(csv_filepath, resource_id, mimetype='text/csv', logger=None):


### PR DESCRIPTION
# Description
There was a previous update to use `TRUNCATE` instead of `DELETE`, when a table's data structure has not changed.
https://github.com/ckan/ckanext-xloader/pull/205/files

As a result the _id column's sequence increments every time data is pushed to the datastore. We should add `RESTART IDENTITY` to restart the _id column's sequence.